### PR TITLE
Update AwsEdgeResolver.findUniqueResourceId

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 18
           registry-url: https://registry.npmjs.org/
@@ -21,6 +21,7 @@ jobs:
 
       - name: Unit/Snapshot tests
         run: |
+            npx browserslist@latest --update-db --yes
             npm run test
             npx eslint . --ext .ts || true
 

--- a/src/diagram/aws/aws-edge-resolver.ts
+++ b/src/diagram/aws/aws-edge-resolver.ts
@@ -1,6 +1,6 @@
 import {Diagram} from "../diagram"
 import * as cdk from "../../cdk"
-import * as _ from "lodash"
+import _ from "lodash"
 import {makeUniqueId} from "@aws-cdk/core/lib/private/uniqueid"
 import {Component, ComponentTags} from "../component/component"
 import {AwsDiagramGenerator} from "./aws-diagram-generator"
@@ -46,7 +46,7 @@ export class AwsEdgeResolver {
         const cdkStackTree = originComponent.treeAncestorWithTag(ComponentTags.isCdkStack, "true")
 
         if (cdkStackTree) {
-            let targetComponent = this.findTargetComponent(cdkStackTree, targetString)
+            const targetComponent = this.findTargetComponent(cdkStackTree, targetString)
 
             if (targetComponent != null) {
                 originComponent.links.addLink(targetComponent)
@@ -130,7 +130,9 @@ export class AwsEdgeResolver {
             if (key === "Fn::ImportValue" && object[key] !== undefined) {
                 try {
                     edgeTargets.push(EdgeTargetStackExport.fromFnImportValue(object[key] as string))
-                } catch (e) {}
+                } catch (error) {
+                    console.log("error parsing Fn::ImportValue: " + error);
+                }
             }
 
             if (key === "Ref" && (typeof object[key] === "string")) {
@@ -145,7 +147,7 @@ export class AwsEdgeResolver {
         return _.uniqWith(edgeTargets, ((a: EdgeTarget, b: EdgeTarget) => a.isEqual(b)))
     }
 
-    scrapeAllStrings(object: any): Set<EdgeTarget> {
+    scrapeAllStrings(object: null | String | Array<any> | object | unknown): Set<EdgeTarget> {
 
         if (object === null || object === undefined) {
             return new Set<EdgeTarget>()

--- a/src/diagram/aws/aws-edge-resolver.ts
+++ b/src/diagram/aws/aws-edge-resolver.ts
@@ -8,6 +8,12 @@ import {DiagramComponent} from "../component/diagram-component"
 import {RootComponent} from "../component/root-component"
 import {EdgeTarget, EdgeTargetSimpleString, EdgeTargetStackExport} from "./edge-target"
 
+
+/**
+ * Resources with this ID are complete hidden from the logical ID calculation.
+ */
+const HIDDEN_ID = 'Default';
+
 /**
  * Finds references between nodes in AWS-CDK trees and converts them to Diagrams subComponent links
  */
@@ -85,10 +91,9 @@ export class AwsEdgeResolver {
     }
 
     private findUniqueResourceId(component: Component): string | boolean {
-
         const stackDepth = component.treeAncestorWithTag(ComponentTags.isCdkStack, "true")
-        const pathParts: string[] = component.idPathParts().slice(stackDepth.depth())
-
+        const pathParts: string[] = component.idPathParts().slice(stackDepth.depth()).filter(x => x !== HIDDEN_ID);
+        
         if (pathParts.length === 0) return false
 
         return makeUniqueId(pathParts)

--- a/src/diagram/aws/edge-target.ts
+++ b/src/diagram/aws/edge-target.ts
@@ -1,7 +1,7 @@
 import {AwsDiagramGenerator} from "./aws-diagram-generator"
 
 export abstract class EdgeTarget {
-    abstract isEqual(other: EdgeTarget)
+    abstract isEqual(other: EdgeTarget): boolean
 }
 
 export class EdgeTargetSimpleString extends EdgeTarget {
@@ -31,6 +31,9 @@ export class EdgeTargetStackExport extends EdgeTarget {
     }
 
     static fromFnImportValue(value: string) {
+        if (value.length > 1000) {
+            throw new Error("Input too long");
+        }
         const matches = value.match(/([^:]*):(.*)/)
 
         if (!matches) throw new Error(`FnImportValue not in expected form: ${value}`)

--- a/src/render/graphviz/graphviz.ts
+++ b/src/render/graphviz/graphviz.ts
@@ -7,12 +7,14 @@ import chalk from "chalk"
 import terminalLink from "terminal-link"
 
 const sanitizeFilename = require('sanitize-filename')
-const exec = util.promisify(childProcess.exec)
+const execFile = util.promisify(childProcess.execFile)
 
 import * as diagram from "../../diagram"
 import {DiagramRenderer, RenderingOutput, RenderingProps, RenderingError} from "../diagram-renderer"
 import {GraphvizGenerator} from "./GraphvizGenerator"
 import * as path from "path"
+
+
 
 export class GraphvizRenderingProps extends RenderingProps {
     diagram: diagram.Diagram
@@ -90,16 +92,13 @@ export class Graphviz implements DiagramRenderer {
     }
 
     private static async dotToPng(sourceDotFile: string, targetPngFile: string) {
-
-        const cmdParts = [
-            Graphviz.GRAPHVIZ_BINARY,
+        const {stdout, stderr} = await execFile(Graphviz.GRAPHVIZ_BINARY, [
             Graphviz.sanitizeAndResolvePath(sourceDotFile),
             `-T png`,
             `>`,
             Graphviz.sanitizeAndResolvePath(targetPngFile)
-        ]
+        ])
 
-        const {stdout, stderr} = await exec(cmdParts.join(" "))
 
         const fileExists = fs.existsSync(targetPngFile)
         if (!fileExists) {

--- a/src/render/graphviz/graphviz.ts
+++ b/src/render/graphviz/graphviz.ts
@@ -1,12 +1,12 @@
 import * as fs from 'fs'
 import * as util from 'util'
-import * as hasbin from 'hasbin'
+import hasbin from 'hasbin'
 import {toDot} from "ts-graphviz"
 import childProcess from "child_process"
 import chalk from "chalk"
 import terminalLink from "terminal-link"
 
-const sanitizeFilename = require('sanitize-filename')
+import sanitizeFilename from 'sanitize-filename'
 const execFile = util.promisify(childProcess.execFile)
 
 import * as diagram from "../../diagram"

--- a/src/render/graphviz/graphviz.ts
+++ b/src/render/graphviz/graphviz.ts
@@ -94,7 +94,7 @@ export class Graphviz implements DiagramRenderer {
     private static async dotToPng(sourceDotFile: string, targetPngFile: string) {
         const {stdout, stderr} = await execFile(Graphviz.GRAPHVIZ_BINARY, [
             Graphviz.sanitizeAndResolvePath(sourceDotFile),
-            `-T png`,
+            `-Tpng`,
             `>`,
             Graphviz.sanitizeAndResolvePath(targetPngFile)
         ])


### PR DESCRIPTION
In the makeUniqueId function in AWS core, there is first a filter on HIDDEN_ID ('Default') which can lead Error: 

`Error: Unable to calculate a unique id for an empty set of components`