### PR TITLE
Add fix for: unique id error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Unit/Snapshot tests
         run: |
+            npx browserslist@latest --update-db --yes
             npm run test
             npx eslint . --ext .ts || true
 

--- a/src/diagram/aws/aws-edge-resolver.ts
+++ b/src/diagram/aws/aws-edge-resolver.ts
@@ -1,12 +1,18 @@
 import {Diagram} from "../diagram"
 import * as cdk from "../../cdk"
-import * as _ from "lodash"
+import _ from "lodash"
 import {makeUniqueId} from "@aws-cdk/core/lib/private/uniqueid"
 import {Component, ComponentTags} from "../component/component"
 import {AwsDiagramGenerator} from "./aws-diagram-generator"
 import {DiagramComponent} from "../component/diagram-component"
 import {RootComponent} from "../component/root-component"
 import {EdgeTarget, EdgeTargetSimpleString, EdgeTargetStackExport} from "./edge-target"
+
+/**
+ * Resources with this ID are complete hidden from the logical ID calculation.
+ */
+const HIDDEN_ID = 'Default';
+
 
 /**
  * Finds references between nodes in AWS-CDK trees and converts them to Diagrams subComponent links
@@ -87,7 +93,7 @@ export class AwsEdgeResolver {
     private findUniqueResourceId(component: Component): string | boolean {
 
         const stackDepth = component.treeAncestorWithTag(ComponentTags.isCdkStack, "true")
-        const pathParts: string[] = component.idPathParts().slice(stackDepth.depth())
+        const pathParts: string[] = component.idPathParts().slice(stackDepth.depth()).filter(x => x !== HIDDEN_ID);
 
         if (pathParts.length === 0) return false
 


### PR DESCRIPTION
Fix for error:


```output
Failed to generate diagram - Error: Unable to calculate a unique id for an empty set of components
node_modules/cdk-dia/node_modules/@aws-cdk/core/lib/private/uniqueid.js:33
        throw new Error('Unable to calculate a unique id for an empty set of components');
              ^

Error: Unable to calculate a unique id for an empty set of components
    at makeUniqueId (node_modules/cdk-dia/node_modules/@aws-cdk/core/lib/private/uniqueid.js:33:15)
    at AwsEdgeResolver.findUniqueResourceId (node_modules/cdk-dia/dist/src/diagram/aws/aws-edge-resolver.js:83:44)
    at node_modules/cdk-dia/dist/src/diagram/aws/aws-edge-resolver.js:55:47
    at DiagramComponent.subTreeFindComponentRec (node_modules/cdk-dia/dist/src/diagram/component/component.js:137:13)
    at DiagramComponent.subTreeFindComponent (node_modules/cdk-dia/dist/src/diagram/component/component.js:134:21)
    at node_modules/cdk-dia/dist/src/diagram/component/component.js:140:23
    at Array.map (<anonymous>)
    at DiagramComponent.subTreeFindComponentRec (node_modules/cdk-dia/dist/src/diagram/component/component.js:139:40)
    at DiagramComponent.subTreeFindComponent (node_modules/cdk-dia/dist/src/diagram/component/component.js:134:21)
    at AwsEdgeResolver.findTargetComponent (node_modules/cdk-dia/dist/src/diagram/aws/aws-edge-resolver.js:54:47)

```